### PR TITLE
bugfix:  jsoninfo segfault on ar71xx

### DIFF
--- a/lib/info/json_helpers.c
+++ b/lib/info/json_helpers.c
@@ -187,6 +187,8 @@ void abuf_json_int(struct json_session *session, struct autobuf *abuf, const cha
 }
 
 void abuf_json_float(struct json_session *session, struct autobuf *abuf, const char* key, double value) {
+#define isinf(x) __builtin_isinf(x)
+#define isnan(x) __builtin_isnan(x)
   double v = value;
   int isInf = isinf(v);
 


### PR DESCRIPTION
olsrv1:  0.9.6.2-git_8e32ff4-hash_cdaa6990297f6561cff31a78a3e5d4e6
openwrt:  Chaos Calmer r48676
architecture:   ar71xx (Ubiquiti AirMax line -- Failed on NSM2 XM,
bullet M2, NS M2 Loco, a couple others)
linux-3.18.29

Program received signal SIGSEGV, Segmentation fault.
0x00000000 in ?? ()
(gdb) bt
#0  0x00000000 in ?? ()
#1  0x77cae67a in abuf_json_float (session=0x77cc33b0 <json_session>,
abuf=<optimized out>, key=<optimized out>, value=0)
     at ../info/json_helpers.c:191
#2  0x77caa4b4 in ipc_print_links (abuf=0x77cc4420 <info_cache+32>) at
src/olsrd_jsoninfo.c:535
#3  0x77caf30a in send_info_from_table (abuf=<optimized out>,
send_what=<optimized out>, funcs=<optimized out>, funcsSize=<optimized
out>,
     outputLength=0x7fff6120) at ../info/olsrd_info.c:447
#4  0x77caf74c in send_info (req=<optimized out>,
add_headers=<optimized out>, send_what=16383, the_socket=<optimized
out>, status=200)
     at ../info/olsrd_info.c:516
#5  0x77cafdb4 in ipc_action (fd=<optimized out>, data=<optimized
out>, flags=<optimized out>) at ../info/olsrd_info.c:950
#6  0x0040b7e2 in poll_sockets () at src/scheduler.c:394
#7  0x0040c382 in olsr_scheduler () at src/scheduler.c:552
#8  0x00407fb2 in main (argc=<optimized out>, argv=<optimized out>) at
src/main.c:775
(gdb)